### PR TITLE
Fix race condition in threadpool_wait

### DIFF
--- a/cthreadpool.c
+++ b/cthreadpool.c
@@ -63,9 +63,11 @@ void threadpool_add_work(const threadpool_t *threadpool, void *(*worker_func)(vo
 // threadpool wait
 void threadpool_wait(threadpool_t *threadpool) {
     pthread_mutex_lock(&threadpool->threadpool_thread_count_mutex);
-    while (threadpool->jobqueue->len || atomic_load(&threadpool->num_threads_working)) {
+    while ((pthread_mutex_lock(&threadpool->jobqueue->jobqueue_mutex), threadpool->jobqueue->len) || atomic_load(&threadpool->num_threads_working)) {
+		pthread_mutex_unlock(&threadpool->jobqueue->jobqueue_mutex);
         pthread_cond_wait(&threadpool->threadpool_thread_idle_cond, &threadpool->threadpool_thread_count_mutex);
     }
+	pthread_mutex_unlock(&threadpool->jobqueue->jobqueue_mutex);
     pthread_mutex_unlock(&threadpool->threadpool_thread_count_mutex);
 }
 


### PR DESCRIPTION
There exists a race condition in `threadpool_wait` that can cause it to prematurely exit even if `threadpool_add_job` was called very slightly beforehand caused by reading `threadpool->jobqueue->len` without a mutex.